### PR TITLE
fix: MN collateral

### DIFF
--- a/views/masternodes.jade
+++ b/views/masternodes.jade
@@ -55,7 +55,7 @@ block content
             .header-tile.panel-section
               .tile-label
                 | Masternode collateral
-                span.tile-label-value 2000 VLS
+                span.tile-label-value 500 VLS
             .header-tile.panel-section
               .tile-label
                 | Masternode reward


### PR DESCRIPTION
Updated MN collateral from 2000 to 500 VLS in the masternode view